### PR TITLE
DAO-530: Add env vars to home endpoint

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -104,6 +104,15 @@ async function main () {
     res.status(200).end(`OK: ${environment.PORT}`)
   })
 
+  app.get('/', (_, res) => {
+    const envs = {
+      DEFAULT_CURRENCY: environment.DEFAULT_CONVERT_FIAT,
+      CHAIN_IDS: environment.NETWORKS.map(network => network.CHAIN_ID),
+      PROFILE: profile
+    }
+    res.status(200).end(JSON.stringify(envs))
+  })
+
   const httpsAPI : HttpsAPI = new HttpsAPI({
     app,
     dataSourceMapping,


### PR DESCRIPTION
I include the following env vars to this '/':
{
  "PORT": 3000,
  "DEFAULT_CURRENCY": "USD",
  "CHAIN_IDS": [
    31,
    30
  ],
  "PROFILE": "dao"
}