### PR TITLE
fix error handler

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -22,7 +22,7 @@
         "jest"
     ],
     "rules": {
-        "@typescript-eslint/no-unused-vars": "error",
+        "@typescript-eslint/no-unused-vars": ["error", { "argsIgnorePattern": "^_" }],
         "max-len": ["warn", { "code": 120 }]
     }
 }

--- a/src/middleware/index.ts
+++ b/src/middleware/index.ts
@@ -8,7 +8,7 @@ export class CustomError extends Error {
   }
 }
 
-export const errorHandler: ErrorRequestHandler = (error, req, res) => {
+export const errorHandler: ErrorRequestHandler = (error, _req, res, _next) => {
   const status = error.status || 500
   const message = error.message || 'Something went wrong'
   console.error(error)


### PR DESCRIPTION
We need to add the fourth parameter to the error handler function to let Express know that it’s an error handler and prevent it from passing control to the next middleware.

